### PR TITLE
Implement saving feature for buffers

### DIFF
--- a/isobar_core/src/buffer.rs
+++ b/isobar_core/src/buffer.rs
@@ -1661,7 +1661,8 @@ impl BufferSnapshot {
     pub fn iter<'a>(&'a self) -> impl 'a + Iterator<Item = &'a [u16]> {
         self.fragments.iter().filter_map(|fragment| {
             if fragment.is_visible() {
-                Some(fragment.insertion.text.code_units.as_ref())
+                let range = fragment.start_offset..fragment.end_offset;
+                Some(&fragment.insertion.text.code_units[range])
             } else {
                 None
             }

--- a/isobar_core/src/buffer.rs
+++ b/isobar_core/src/buffer.rs
@@ -60,7 +60,6 @@ pub struct Buffer {
 
 pub struct BufferSnapshot {
     fragments: Tree<Fragment>,
-    version: Version,
 }
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Serialize, Hash)]
@@ -661,7 +660,6 @@ impl Buffer {
     pub fn snapshot(&self) -> BufferSnapshot {
         BufferSnapshot {
             fragments: self.fragments.clone(),
-            version: self.version.clone(),
         }
     }
 
@@ -1668,6 +1666,11 @@ impl BufferSnapshot {
             }
         })
     }
+
+    #[cfg(test)]
+    pub fn to_string(&self) -> String {
+        String::from_utf16_lossy(&self.iter().flat_map(|c|c ).cloned().collect::<Vec<u16>>())
+    }
 }
 
 impl Point {
@@ -2628,6 +2631,22 @@ mod tests {
         assert_eq!(buffer.offset_for_anchor(&after_start_anchor).unwrap(), 3);
         assert_eq!(buffer.offset_for_anchor(&before_end_anchor).unwrap(), 6);
         assert_eq!(buffer.offset_for_anchor(&after_end_anchor).unwrap(), 9);
+    }
+
+    #[test]
+    fn test_snapshot() {
+        let mut buffer = Buffer::new(0);
+        buffer.edit(&[0..0], "abcdefghi")
+        buffer.edit(&[0..0], "DEF");
+
+        let snapshot = buffer.snapshot();
+        assert_eq!(buffer.to_string(), String::from("abcDEFghi"));
+        assert_eq!(snapshot.to_string(), String::from("abcDEFghi"));
+
+        buffer.edit(&[0..1], "A");
+        buffer.edit(&[8..8], "I");
+        assert_eq!(buffer.to_string(), String::from("AbcDEFGhI"));
+        assert_eq!(snapshot.to_string(), String::from("abcDEFghi"));
     }
 
     #[test]

--- a/isobar_core/src/fs.rs
+++ b/isobar_core/src/fs.rs
@@ -1,3 +1,4 @@
+use buffer::BufferSnapshot;
 use cross_platform;
 use futures::{Async, Future, Stream};
 use notify_cell::NotifyCell;
@@ -35,6 +36,10 @@ pub trait FileProvider {
 pub trait File {
     fn id(&self) -> FileId;
     fn read(&self) -> Box<Future<Item = String, Error = io::Error>>;
+    fn write_snapshot(
+        &self,
+        snapshot: BufferSnapshot,
+    ) -> Box<Future<Item = (), Error = io::Error>>;
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/isobar_core/src/fs.rs
+++ b/isobar_core/src/fs.rs
@@ -36,10 +36,8 @@ pub trait FileProvider {
 pub trait File {
     fn id(&self) -> FileId;
     fn read(&self) -> Box<Future<Item = String, Error = io::Error>>;
-    fn write_snapshot(
-        &self,
-        snapshot: BufferSnapshot,
-    ) -> Box<Future<Item = (), Error = io::Error>>;
+    fn write_snapshot(&self, snapshot: BufferSnapshot)
+        -> Box<Future<Item = (), Error = io::Error>>;
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -545,6 +543,18 @@ pub(crate) mod tests {
             Box::new(NextTick::new().then(move |_| {
                 let file = file.borrow();
                 future::ok(file.content.clone())
+            }))
+        }
+
+        fn write_snapshot(
+            &self,
+            snapshot: BufferSnapshot,
+        ) -> Box<Future<Item = (), Error = io::Error>> {
+            let file = self.0.clone();
+            Box::new(NextTick::new().then(move |_| {
+                let mut file = file.borrow_mut();
+                file.content = snapshot.to_string();
+                future::ok(())
             }))
         }
     }

--- a/isobar_core/src/project.rs
+++ b/isobar_core/src/project.rs
@@ -73,11 +73,15 @@ pub enum RpcRequest {
     OpenBuffer {
         buffer_id: BufferId,
     },
+    SaveBuffer {
+        buffer_id: BufferId,
+    },
 }
 
 #[derive(Deserialize, Serialize)]
 pub enum RpcResponse {
     OpenedBuffer(Result<rpc::ServiceId, Error>),
+    SavedBuffer(Result<(), Error>),
 }
 
 pub struct PathSearch {
@@ -123,6 +127,7 @@ pub enum Error {
     TreeNotFound,
     IoError(String),
     RpcError(rpc::Error),
+    UnexpectedResponse,
 }
 
 impl LocalProject {
@@ -334,6 +339,7 @@ impl Project for RemoteProject {
                                             .map_err(|error| error.into())
                                     })
                             }),
+                            _ => Err(Error::UnexpectedResponse),
                         })
                 }),
         )
@@ -363,13 +369,23 @@ impl Project for RemoteProject {
                                             .map_err(|error| error.into())
                                     })
                             }),
+                            _ => Err(Error::UnexpectedResponse),
                         })
                 }),
         )
     }
 
     fn save_buffer(&self, buffer_id: BufferId) -> Box<Future<Item = (), Error = Error>> {
-        unimplemented!()
+        Box::new(
+            self.service
+                .borrow()
+                .request(RpcRequest::SaveBuffer { buffer_id })
+                .map_err(|error| error.into())
+                .and_then(|response| match response {
+                    RpcResponse::SavedBuffer(result) => result,
+                    _ => Err(Error::UnexpectedResponse),
+                }),
+        )
     }
 
     fn search_paths(
@@ -472,6 +488,12 @@ impl rpc::server::Service for ProjectService {
                     },
                 )))
             }
+            RpcRequest::SaveBuffer { buffer_id } => Some(Box::new(
+                self.project
+                    .borrow()
+                    .save_buffer(buffer_id)
+                    .then(|result| Ok(RpcResponse::SavedBuffer(result))),
+            ))
         }
     }
 }

--- a/isobar_core/src/workspace.rs
+++ b/isobar_core/src/workspace.rs
@@ -7,8 +7,10 @@ use futures::{Future, Poll, Stream};
 use never::Never;
 use notify_cell::NotifyCell;
 use notify_cell::NotifyCellObserver;
-use project::{self, LocalProject, PathSearch, PathSearchStatus, Project, ProjectService,
-              RemoteProject, TreeId};
+use project::{
+    self, LocalProject, PathSearch, PathSearchStatus, Project, ProjectService, RemoteProject,
+    TreeId,
+};
 use rpc::{self, client, server};
 use serde_json;
 use std::cell::{Ref, RefCell, RefMut};
@@ -216,7 +218,7 @@ impl WorkspaceView {
 
     fn open_buffer<T>(&self, buffer: T, selected_range: Option<Range<buffer::Anchor>>)
     where
-        T: 'static + Future<Item = Rc<RefCell<Buffer>>, Error = project::OpenError>,
+        T: 'static + Future<Item = Rc<RefCell<Buffer>>, Error = project::Error>,
     {
         if let Some(window_handle) = self.window_handle.clone() {
             let user_id = self.workspace.borrow().user_id();

--- a/isobar_core/src/workspace.rs
+++ b/isobar_core/src/workspace.rs
@@ -75,6 +75,7 @@ pub struct Anchor {
 enum WorkspaceViewAction {
     ToggleFileFinder,
     ToggleDiscussion,
+    SaveActionBuffer,
 }
 
 impl LocalWorkspace {
@@ -258,6 +259,26 @@ impl WorkspaceView {
                 .unwrap();
         }
     }
+
+    fn save_active_buffer(&self) {
+        if let Some(ref active_buffer_view) = self.active_buffer_view {
+            if let Some(buffer_id) = active_buffer_view.map(|buffer_view| buffer_view.buffer_id()) {
+                let workspace = self.workspace.borrow();
+                self.foreground
+                    .execute(Box::new(workspace.project().save_buffer(buffer_id).then(
+                        |result| {
+                            if let Err(error) = result {
+                                eprintln!("Error saving buffer {:?}", error);
+                                unimplemented!("Error handling for save_buffer: {:?}", error);
+                            } else {
+                                Ok(())
+                            }
+                        },
+                    )))
+                    .unwrap();
+            }
+        }
+    }
 }
 
 impl View for WorkspaceView {
@@ -282,7 +303,8 @@ impl View for WorkspaceView {
         match serde_json::from_value(action) {
             Ok(WorkspaceViewAction::ToggleFileFinder) => self.toggle_file_finder(window),
             Ok(WorkspaceViewAction::ToggleDiscussion) => self.toggle_discussion(window),
-            _ => eprintln!("Unrecognized action"),
+            Ok(WorkspaceViewAction::SaveActionBuffer) => self.save_active_buffer(),
+            Err(error) => eprintln!("Unrecognized action {}", error),
         }
     }
 }

--- a/isobar_server/src/fs.rs
+++ b/isobar_server/src/fs.rs
@@ -4,7 +4,7 @@ use parking_lot::Mutex;
 use std::char::decode_utf16;
 use std::ffi::OsString;
 use std::fs;
-use std::io::{self, Read, Write};
+use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -190,32 +190,38 @@ impl isobar_fs::File for File {
 
     fn write_snapshot(
         &self,
-        shapshot: BufferSnapshot,
+        snapshot: BufferSnapshot,
     ) -> Box<Future<Item = (), Error = io::Error>> {
         let (tx, rx) = futures::sync::oneshot::channel();
         let file = self.file.clone();
         thread::spawn(move || {
             fn write(file: &mut fs::File, snapshot: BufferSnapshot) -> Result<(), io::Error> {
-                let mut buf_writer = io::BufWriter::new(file);
-                let mut encode_buf = [0_u8; 4];
-                for character in snapshot
-                    .iter()
-                    .flat_map(|c| decode_utf16(c.iter().cloned()))
+                let mut size = 0_u64;
                 {
-                    let character = character.map_err(|_| {
-                        io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            "buffer did not contain valid UTF-8",
-                        )
-                    })?;
-                    let encoded_char = character.encode_utf8(&mut encode_buf);
-                    buf_writer.write(encoded_char.as_bytes())?;
+                    let mut buf_writer = io::BufWriter::new(&mut *file);
+                    buf_writer.seek(SeekFrom::Start(0))?;
+                    for character in snapshot
+                        .iter()
+                        .flat_map(|c| decode_utf16(c.iter().cloned()))
+                    {
+                        let character = character.map_err(|_| {
+                            io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "buffer did not contain valid UTF-8",
+                            )
+                        })?;
+                        let mut encode_buf = [0_u8; 4];
+                        let encoded_char = character.encode_utf8(&mut encode_buf);
+                        buf_writer.write(encoded_char.as_bytes())?;
+                        size += encoded_char.len() as u64;
+                    }
                 }
+                file.set_len(size)?;
                 Ok(())
             }
 
             let _ = tx.send(write(&mut file.lock(), snapshot));
         });
-        Box::new(rx.then(|result| result.expect("Sender should no be dropeed")))
+        Box::new(rx.then(|result| result.expect("Sender should not be dropped")))
     }
 }

--- a/isobar_server/src/fs.rs
+++ b/isobar_server/src/fs.rs
@@ -1,13 +1,15 @@
 use futures::{self, Future, Stream};
 use ignore::WalkBuilder;
 use parking_lot::Mutex;
+use std::char::decode_utf16;
 use std::ffi::OsString;
 use std::fs;
-use std::io::{self, Read};
+use std::io::{self, Read, Write};
 use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread;
+use isobar_core::buffer::BufferSnapshot;
 use isobar_core::cross_platform;
 use isobar_core::fs as isobar_fs;
 use isobar_core::notify_cell::NotifyCell;
@@ -139,7 +141,10 @@ impl isobar_fs::FileProvider for FileProvider {
 
         thread::spawn(|| {
             fn open(path: PathBuf) -> Result<File, io::Error> {
-                Ok(File::new(fs::File::open(path)?)?)
+                Ok(File::new(fs::OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(path)?)?)
             }
 
             let _ = tx.send(open(path));
@@ -181,5 +186,36 @@ impl isobar_fs::File for File {
         });
 
         Box::new(rx.then(|result| result.expect("Sender should not be dropped")))
+    }
+
+    fn write_snapshot(
+        &self,
+        shapshot: BufferSnapshot,
+    ) -> Box<Future<Item = (), Error = io::Error>> {
+        let (tx, rx) = futures::sync::oneshot::channel();
+        let file = self.file.clone();
+        thread::spawn(move || {
+            fn write(file: &mut fs::File, snapshot: BufferSnapshot) -> Result<(), io::Error> {
+                let mut buf_writer = io::BufWriter::new(file);
+                let mut encode_buf = [0_u8; 4];
+                for character in snapshot
+                    .iter()
+                    .flat_map(|c| decode_utf16(c.iter().cloned()))
+                {
+                    let character = character.map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "buffer did not contain valid UTF-8",
+                        )
+                    })?;
+                    let encoded_char = character.encode_utf8(&mut encode_buf);
+                    buf_writer.write(encoded_char.as_bytes())?;
+                }
+                Ok(())
+            }
+
+            let _ = tx.send(write(&mut file.lock(), snapshot));
+        });
+        Box::new(rx.then(|result| result.expect("Sender should no be dropeed")))
     }
 }

--- a/isobar_ui/lib/workspace.js
+++ b/isobar_ui/lib/workspace.js
@@ -89,6 +89,9 @@ class Workspace extends React.Component {
       if (event.key === "t") {
         this.props.dispatch({ type: "ToggleFileFinder" })
         event.stopPropagation();
+      } else if (envet.key === "s") {
+        this.props.dispatch({ type: "SaveActiveBuffer" });
+        event.stopPropagation();
       }
     }
   }


### PR DESCRIPTION
This pull request introduces a new `SaveActionBuffer` command that is dispatched when either pressing <kbd>Ctrl</kbd>+<kbd>S</kbd>. This new command applies to both local and remote workspaces, which in the latter case issues a save request to the host owning the buffer.